### PR TITLE
Support UniqueConstrainErrors from newer pinejs versions

### DIFF
--- a/src/errors.ts
+++ b/src/errors.ts
@@ -1,15 +1,15 @@
 import { TypedError } from 'typed-error';
 
 export class ObjectDoesNotExistError extends TypedError {}
+export class UniqueConstraintError extends TypedError {}
 export class UnauthorisedError extends TypedError {}
 export class BadRequestError extends TypedError {}
 export class ServerError extends TypedError {}
 
 export class HttpResponseError extends TypedError {
-	public statusCode: number;
-
-	constructor(message: string | Error, statusCode: number) {
+	constructor(message: string | Error, public statusCode: number) {
 		super(message);
-		this.statusCode = statusCode;
 	}
 }
+
+export class ConflictError extends HttpResponseError {}


### PR DESCRIPTION
This is on top of #11 (so only the latest commit is for review in here atm).
The extra check prepares us for the newer pinejs version which will return 409 errors.
This is expected to happen on the `/v6` endpoint, but also helps open-balena-api users that might be bumping their pinejs version.

Resolves: #10
Change-type: minor
Signed-off-by: Thodoris Greasidis <thodoris@balena.io>